### PR TITLE
Update main-core.yaml

### DIFF
--- a/lumi/template_configs/main-core.yaml
+++ b/lumi/template_configs/main-core.yaml
@@ -11,7 +11,7 @@ defaults:
 - override hydra/job_logging: disabled
 - _self_
 
-config_validation: False
+config_validation: True
 
 hydra:  
   output_subdir: null  
@@ -48,7 +48,6 @@ data:
   processors:
     imputer:
       _target_: anemoi.models.preprocessing.imputer.InputImputer
-      _convert_: all
       config: 
         default: "none"
         mean:  


### PR DESCRIPTION
Now config validation works quite well and might warn us if we try to do something stupid, so I suggest we turn it on. Another pull request will handle the remaining complaints about graph creation from the validation. 

Remove line
`_convert_: all `
since the config validation complains about it. Note that this line is not found in the default `InputImputer` setup in `data.zarr.yaml`, even if it is still present in the [docs](https://anemoi.readthedocs.io/projects/training/en/latest/user-guide/training.html#imputer).