### PR TITLE
Update graph.yaml

### DIFF
--- a/lumi/template_configs/graph.yaml
+++ b/lumi/template_configs/graph.yaml
@@ -26,9 +26,8 @@ nodes:
         masks:
           _target_: anemoi.graphs.nodes.attributes.CutOutMask
       area_weight:
-        _target_: anemoi.graphs.nodes.attributes.UniformWeights # options: Uniform
-        #mask_node_attr_name: cutout_mask ---> this should work with anemoi.graphs.nodes.attributes.MaskedPlanarAreaWeights, but not here
-        norm: unit-max
+        _target_: anemoi.graphs.nodes.attributes.MaskedPlanarAreaWeights
+        norm: unit-max # options: unit-max, unit-sum, unit-std
   hidden:
     node_builder:
       _target_: anemoi.graphs.nodes.LimitedAreaTriNodes


### PR DESCRIPTION
While creating new graph with thinning came across this:
_"In contrast, for limited area graphs, we recommend that users use PlanarAreaWeights to avoid some errors that may occur depending on the dataset configuration.
...
This method can be extended to MaskedPlanarAreaWeights, which computes planar area weights but restricts the computation to a masked region by setting the weights outside the mask to zero." [https://anemoi.readthedocs.io/projects/graphs/en/latest/graphs/node_attributes/weights.html](https://github.com/orgs/metno/projects/25/views/url)_

Seems `UniformWeights` is not recomended for LAM, so lets change it? We have a new graph with thinning that already contains this change:
`/scratch/project_465001902/graphs/LAM-trimedge-10-res-12-scale12-thinning-4.pt`

**TODO**

- [ ] test it with other setups (only tried it here so far: `/scratch/project_465001902/experiments/no-zeta/data-p1_model-p8/run-anemoi-ocean/lumi`
- [ ] pot this graph