### PR TITLE
Inakbk 2x bug fixes

### DIFF
--- a/lumi/run_pytorch.sh
+++ b/lumi/run_pytorch.sh
@@ -107,6 +107,9 @@ export MASTER_PORT=29500
 export WORLD_SIZE=$SLURM_NPROCS
 export RANK=$SLURM_PROCID
 
+# "If reserved but unallocated memory is large try setting to avoid fragmentation"
+PYTORCH_HIP_ALLOC_CONF=expandable_segments:True,garbage_collection_threshold:0.5
+
 export HSA_FORCE_FINE_GRAIN_PCIE=1
 export HYDRA_FULL_ERROR=1
 export AIFS_BASE_SEED=1337420

--- a/lumi/template_configs/main-core.yaml
+++ b/lumi/template_configs/main-core.yaml
@@ -226,6 +226,9 @@ model:
     attribute_name: cutout_mask
 
 training:
+  # This supposedly fixes LUMI memory bug affecting loss
+  precision: bf16-mixed
+  
   # This section is to avoid using variable_loss_scaling 
   training_loss:
     # loss class to initialise


### PR DESCRIPTION
Two fixes:

1. Using  bf16-mixed precision in training, this makes the loss smooth and not "jumping". see anemoi-core issues on this 
2. Setting env variable to release unused but allocated memory by pytorch. The env var was suggested by error messages when crashing due to HIP
